### PR TITLE
fix: correct header slicing in Excel parsing to include all columns

### DIFF
--- a/src/utils/parseExcel.ts
+++ b/src/utils/parseExcel.ts
@@ -28,7 +28,7 @@ export function parseExcel(file: File, timeRange: [number, number]): Promise<Wel
           reject(new Error('Excel file format is not valid'))
           return
         }
-        const header = trimmed[0].slice(1).map(v => String(v))
+        const header = trimmed[0].slice(0).map(v => String(v))
         const totalMinutes = header.length
         if (totalMinutes < end) {
           reject(new Error(`Excel file only contains ${totalMinutes} minutes of data`))


### PR DESCRIPTION
fix the slice so it allows correct column size